### PR TITLE
Added dtype to config in Loss.

### DIFF
--- a/keras_core/losses/loss.py
+++ b/keras_core/losses/loss.py
@@ -27,6 +27,7 @@ class Loss:
     def __init__(self, name=None, reduction="sum_over_batch_size", dtype=None):
         self.name = name or auto_name(self.__class__.__name__)
         self.reduction = standardize_reduction(reduction)
+        self._dtype_config = dtype
         self.dtype = dtype or backend.floatx()
 
     def __call__(self, y_true, y_pred, sample_weight=None):
@@ -64,7 +65,7 @@ class Loss:
         raise NotImplementedError
 
     def get_config(self):
-        return {"name": self.name, "reduction": self.reduction}
+        return {"name": self.name, "reduction": self.reduction, "dtype": self._dtype_config}
 
     @classmethod
     def from_config(cls, config):


### PR DESCRIPTION
Thank you very much for the update in `Loss` . 

I have following question/suggestion, which I hope is okay and does not clash with the saving/loading behaviour of models: I added the dtype information to the config of `Loss` such that the default floatx behaviour can be maintained even when created from config. If `dtype` is specified, then the `Loss` will set dtype from config.

If the dtype should not be passed on to the config then this pull request should be canceled.